### PR TITLE
Update Dockerfile to use entrypoint correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.9-slim-buster
+FROM --platform=linux/amd64 python:3.9-slim-buster
 
 ENV POETRY_VERSION=1.4 \
     POETRY_VIRTUALENVS_CREATE=false
@@ -22,5 +22,5 @@ COPY . /code/
 # Project initialization:
 RUN poetry install --no-interaction
 
-ENTRYPOINT ["c19dfm"]
+ENTRYPOINT ["poetry", "run", "c19dfm"]
 CMD ["--help"]


### PR DESCRIPTION
Fixes #75

Also force linux/amd64 build for ARM architecture b/c otherwise you get annoying build errors I don't want to deal with supporting.